### PR TITLE
DOC: Improve clarity, fix some errors, and remove duplicate instructions

### DIFF
--- a/docs/source/action/designer_expert.rst
+++ b/docs/source/action/designer_expert.rst
@@ -37,12 +37,19 @@ The finished result will look like this:
      :scale: 100 %
      :align: center
 
+  Save this file as ``expert_motor.ui``.
+
+  .. warning::
+     For this tutorial it is important to use this file name, as it will be referenced
+     at the other sections. If you change it please remember to also change at the
+     next steps when referenced.
+
 * **Step 2.**
 
   With the new form available, let's add a ``QVBoxLayout`` widget and make
   it fill the whole form. Let's select ``Layout Vertically`` for the Form.
 
-  .. figure:: /_static/action/inline/inline_layout.gif
+  .. figure:: /_static/action/expert/expert_layout.gif
      :scale: 100 %
      :align: center
 
@@ -54,7 +61,6 @@ The finished result will look like this:
      :scale: 70 %
      :align: center
 
-
   * **Step 3.1.**
 
     The first ``QLabel`` will be the title of our screen:
@@ -62,32 +68,39 @@ The finished result will look like this:
     #. Drag and drop a ``QLabel`` into the previously added ``QVBoxLayout``.
     #. Set the ``text`` property of this label to: ``Configuring Motor: ${MOTOR}``.
 
-       .. note::
+        .. note::
 
-          :ref:`Macros` are not something exclusive to PyDM Widgets, they can be
-          used with any kind of widget and in any property, in this case we are
-          using it to add the motor ``PV`` name to the title.  However, due to
-          limitations in Qt Designer, you cannot specify a macro for a variable
-          that is numeric-only inside designer itself.  An (unfortunate) work-around
-          is to edit the .ui file in a text editor, and insert your macro variable 
-          into the XML that defines the display.
+            :ref:`Macros` are not something exclusive to PyDM Widgets, they can be
+            used with any kind of widget and in any property, in this case we are
+            using it to add the motor ``PV`` name to the title.  However, due to
+            limitations in Qt Designer, you cannot specify a macro for a variable
+            that is numeric-only inside designer itself.  An (unfortunate) work-around
+            is to edit the .ui file in a text editor, and insert your macro variable
+            into the XML that defines the display.
 
     #. In order to make the label look better as a title, add the following to
        the ``stylesheet`` property:
 
-       .. code-block:: css
+            .. code-block:: css
 
-           QLabel {
-            qproperty-alignment: AlignCenter;
-            border: 1px solid #FF17365D;
-            border-top-left-radius: 15px;
-            border-top-right-radius: 15px;
-            background-color: #FF17365D;
-            padding: 5px 0px;
-            color: rgb(255, 255, 255);
-            max-height: 25px;
-            font-size: 14px;
-           }
+                QLabel {
+                    qproperty-alignment: AlignCenter;
+                    border: 1px solid #FF17365D;
+                    border-top-left-radius: 15px;
+                    border-top-right-radius: 15px;
+                    background-color: #FF17365D;
+                    padding: 5px 0px;
+                    color: rgb(255, 255, 255);
+                    max-height: 25px;
+                    font-size: 14px;
+                }
+
+            .. note::
+
+                If you click into the edit box next to the ``stylesheet`` property label, and then click on the "..."
+                button on the right of the edit box, a stylesheet dialog will pop up, and you can copy and paste the
+                stylesheet contents more easily. Alternatively, you can right click on the ``QLabel`` widget, and select
+                the "Change styleSheet..." menu item to bring up the same stylesheet dialog.
 
   * **Step 3.2.**
 
@@ -120,18 +133,6 @@ The finished result will look like this:
        - This will make the QFormLayout fill the whole space of the ``QFrame``
          and make our form behave better when resizing.
 
-    #. Set the ``frameShadow`` property to ``Raised``.
-    #. In order to add some nice rounded corners to this frame, add the following
-       to the ``stylesheet`` property:
-
-       .. code-block:: css
-
-           QFrame#frame{
-        	border: 1px solid #FF17365D;
-	        border-bottom-left-radius: 15px;
-	        border-bottom-right-radius: 15px;
-           }
-
   * **Step 3.4.**
 
     Now that we have our ``QFormLayout`` ready, it is time to start adding the form
@@ -160,11 +161,6 @@ The finished result will look like this:
     #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
        under the previously added components.
 
-       .. note::
-
-          The area will be highlighted with blue line. When that happens you will
-          know that the widget will be placed at the expected place.
-
     #. Set the ``text`` property to ``Position:``.
     #. Drag and drop a ``PyDMLineEdit`` into the ``QFormLayout`` paying attention to
        add it on the side of the previously added ``QLabel``.
@@ -175,8 +171,8 @@ The finished result will look like this:
 
   * **Step 3.6.**
 
-    Let's now add a ``QLabel``, and this time, a ``PyDMLabel`` that
-    will be used to read the **Readback Position** of the Motor:
+    Let's now add a ``QLabel``, and this time, also a ``PyDMLabel`` that will be used to read the
+    **Readback Position** of the Motor:
 
     #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
        under the previously added components.
@@ -186,6 +182,7 @@ The finished result will look like this:
     #. Set the ``channel`` property to ``ca://${MOTOR}.RBV``.
     #. Set the ``displayFormat`` property to ``Decimal``.
     #. Select the ``showUnits`` property.
+    #. Expand the ``maximumSize`` property and set the ``Width`` property to ``150``.
 
   * **Step 3.7.**
 
@@ -225,7 +222,7 @@ The finished result will look like this:
     and make sure that all is well positioned and behaving nicely.
 
     #. Using the ``Object Inspector`` at the top-right corner of the Qt Designer
-       window, select the ``formLayout`` object and set the properties according
+       window, select the ``QFormLayout`` object and set the properties according
        to the table below:
 
        ==================================  ==================
@@ -289,12 +286,7 @@ The finished result will look like this:
 
 * **Step 4.**
 
-  Save this file as ``expert_motor.ui``.
-
-  .. warning::
-     For this tutorial it is important to use this file name, as it will be referenced
-     at the other sections. If you change it please remember to also change at the
-     next steps when referenced.
+  Save this file as ``expert_motor.ui`` again if necessary.
 
 * **Step 5.**
 

--- a/docs/source/action/designer_inline.rst
+++ b/docs/source/action/designer_inline.rst
@@ -36,10 +36,20 @@ The finished result will look like this:
      :scale: 100 %
      :align: center
 
+  Save this file as ``inline_motor.ui``.
+
+  .. warning::
+     For this tutorial it is important to use this file name as it will be referenced
+     at the other sections. If you change it, please remember to also change it in the
+     next steps when referenced.
+
 * **Step 2.**
 
-  With the new form available, let's add a GridLayout widget to it and to make it
-  fill the whole form let's select ``Layout Vertically`` for the Form.
+  With the new form available, let's add a ``QGridLayout`` widget to it. Look for the "Grid Layout" widget in the Widget
+  Box of Qt Designer.
+
+  To make the ``QGridLayout`` fill the whole form, click the canvas (outside of the widget) and select ``Layout
+  Vertically`` from the Layout context menu.
 
   .. figure:: /_static/action/inline/inline_layout.gif
      :scale: 100 %
@@ -58,19 +68,24 @@ The finished result will look like this:
     The first ``PyDMLabel`` will display the description of the Motor:
 
     #. Drag and drop a ``PyDMLabel`` at the previously added ``GridLayout``.
-    #. Set the ``Channel`` property of this label to: ``ca://${MOTOR}.DESC``.
+    #. Click on the ``PyDMLabel`` and locate the ``channel`` property in the Property Editor. Set the ``channel``
+       property of this label to: ``ca://${MOTOR}.DESC``.
 
        * ${MOTOR} is the macro that will later be replaced by the value sent by screens
          using this widget in embedded displays, related displays or even when launching
          using the command line.
 
-    #. Set the ``displayFormat`` property of this label to: ``String``.
+    #. Locate the ``displayFormat`` property in the Property Editor. Set the ``displayFormat`` property of this label
+       to: ``String``.
     #. Expand the ``Font`` property and mark the checkbox for ``Bold``.
 
     .. figure:: /_static/action/inline/inline_desc.gif
        :scale: 100 %
        :align: center
 
+    .. note::
+        You can type the name of the property you want to look for into the Filter edit box of the Property Editor to
+        quickly jump to that property.
 
   * **Step 3.2.**
 
@@ -80,7 +95,7 @@ The finished result will look like this:
     #. Drag and drop a ``PyDMLineEdit`` at the ``GridLayout`` on the side of the
        previously added ``PyDMLabel`` (**Note**: The border will become blue showing that
        the widget will be placed on the side and not on top or under the other widget).
-    #. Set the ``Channel`` property of this line edit to: ``ca://${MOTOR}.VAL``.
+    #. Set the ``channel`` property of this line edit to: ``ca://${MOTOR}.VAL``.
     #. Change its ``displayFormat`` property to ``Decimal``.
     #. Expand the ``sizePolicy`` property and set ``Horizontal Policy`` and
        ``Vertical Policy`` to ``Fixed``.
@@ -103,7 +118,7 @@ The finished result will look like this:
 
     #. Drag and drop a ``PyDMLabel`` at the ``GridLayout`` on the side of the
        previously added ``PyDMLineEdit``.
-    #. Set the ``Channel`` property of this line edit to: ``ca://${MOTOR}.RBV``.
+    #. Set the ``channel`` property of this line edit to: ``ca://${MOTOR}.RBV``.
     #. Change its ``displayFormat`` property to ``Decimal``.
     #. Expand the ``sizePolicy`` property and set ``Horizontal Policy`` and
        ``Vertical Policy`` to ``Fixed``.
@@ -126,7 +141,7 @@ The finished result will look like this:
 
     #. Drag and drop a ``PyDMByteIndicator`` at the ``GridLayout`` on the side of the
        previously added ``PyDMLabel``.
-    #. Set the ``Channel`` property of this line edit to: ``ca://${MOTOR}.MOVN``.
+    #. Set the ``channel`` property of this line edit to: ``ca://${MOTOR}.MOVN``.
     #. Turn off the ``showLabels`` property since we are only interested on the
        color for this widget.
     #. Set the ``circles`` property so we have a circle instead of a square.
@@ -271,12 +286,7 @@ The finished result will look like this:
 
 * **Step 4.**
 
-  Save this file as ``inline_motor.ui``.
-
-  .. warning::
-     For this tutorial it is important to use this file name as it will be referenced
-     at the other sections. If you change it, please remember to also change it in the
-     next steps when referenced.
+  Save this file as ``inline_motor.ui`` again if necessary.
 
 * **Step 5.**
 

--- a/docs/source/action/designer_main.rst
+++ b/docs/source/action/designer_main.rst
@@ -35,6 +35,13 @@ The finished result will look like this:
      :scale: 100 %
      :align: center
 
+  Save this file as ``main.ui``.
+
+  .. warning::
+     For this tutorial it is important to use this file name, as it will be referenced
+     at the other sections. If you change it please remember to also change at the
+     next steps when referenced.
+
 * **Step 2.**
 
   With the new form available, let's add a ``QVBoxLayout`` widget and make
@@ -58,8 +65,7 @@ The finished result will look like this:
 
     #. Drag and drop a ``QLabel`` into the previously added ``QVBoxLayout``.
     #. Set the ``text`` property of this label to: ``Beam Alignment``.
-    #. In order to make the label look better as a title, add the following to
-       the ``stylesheet`` property:
+    #. In order to make the label look better as a title, add the following to the ``stylesheet`` property:
 
        .. code-block:: css
 
@@ -75,7 +81,6 @@ The finished result will look like this:
                 font-size: 14px;
             }
 
-
   * **Step 3.2.**
 
     The second widget that we will add is a ``PyDMImageView``, which will display
@@ -83,6 +88,13 @@ The finished result will look like this:
 
     #. Drag and drop a ``PyDMImageView`` into the previously added ``QVBoxLayout`` under
        the ``QLabel`` that was added at **Step 3.1**.
+    #. Set the ``objectName`` property of this widget to ``imageView``.
+
+        .. important::
+
+            It is very important to set the ``objectName`` property of widgets as instructed, using Qt Designer, so that
+            you can refer to them by the Python code you are to add in the later steps.
+
     #. Set the ``imageChannel`` property to ``ca://13SIM1:image1:ArrayData``.
     #. Set the ``widthChannel`` property to ``ca://13SIM1:image1:ArraySize1_RBV``.
     #. Set the ``readingOrder`` property to ``Clike``.
@@ -102,49 +114,27 @@ The finished result will look like this:
     The fourth widget that we will add is a ``QLabel``, which will updated with
     the result of the calculation of beam position at the next section (:ref:`LittleCode`):
 
-    #. Drag and drop a ``QVBoxLayout`` into ``QVBoxLayout`` that was added at
-       **Step 3.3**.
+    #. Drag and drop a ``QLabel`` into ``QVBoxLayout`` that was added at
+       **Step 3.3**. Make sure you drop this ``QLabel`` widget into the ``QVBoxLayout`` at **Step 3.3** and not the
+       ``QVBoxLayout`` added at **Step 3.2**.
     #. Set the ``objectName`` property of this widget to ``lbl_blobs``.
 
        .. important::
 
-          It is very important to set the ``objectName`` property of widgets at
-          the designer that you intend to access them using Code otherwise the
-          names will be automatically assigned and will not make much sense later
-          on.
+            It is very important to set the ``objectName`` property of widgets as instructed, using Qt Designer, so that
+            you can refer to them by the Python code you are to add in the later steps.
 
     #. Set the ``text`` property to empty so this label will only show information
        when we write to it using the code later on.
 
   * **Step 3.5.**
 
-    The fifth widget that we will add is a ``QLabel``, which will updated with
-    the result of the calculation of beam position at the next section (:ref:`LittleCode`):
+    The fifth widget that we will add is another ``QLabel``, which will the title of our controls area:
 
-    #. Drag and drop a ``QVBoxLayout`` into ``QVBoxLayout`` that was added at
-       **Step 3.3**.
-    #. Set the ``objectName`` property of this widget to ``lbl_blobs``.
-
-       .. important::
-
-          It is very important to set the ``objectName`` property of widgets at
-          the designer that you intend to access them using Code otherwise the
-          names will be automatically assigned and will not make much sense later
-          on.
-
-    #. Set the ``text`` property to empty so this label will only show information
-       when we write to it using the code later on.
-
-  * **Step 3.6.**
-
-    The sixty widget that we will add is another ``QLabel``, which will the title
-    of our controls area:
-
-    #. Drag and drop a ``QLabel`` into ``QVBoxLayout`` that was added at
-       **Step 3.3** right under the QLabel added at **Step 3.5**.
+    #. Drag and drop a ``QLabel`` under the QLabel added at **Step 3.4**. The new label should be directly contained by
+       the ``QVBoxLayout`` that was added at **Step 3.3**.
     #. Set the ``text`` property of this label to: ``Controls``.
-    #. In order to make the label look better as a title, add the following to
-       the ``stylesheet`` property:
+    #. In order to make the label look better as a title, add the following to the ``stylesheet`` property:
 
        .. code-block:: css
 
@@ -160,12 +150,12 @@ The finished result will look like this:
                 font-size: 14px;
             }
 
-  * **Step 3.7.**
+  * **Step 3.6.**
 
-    The seventh widget that we will add is a ``QFrame``, which will be the container
+    The sixth widget that we will add is a ``QFrame``, which will be the container
     for our two motors ``Embedded Displays``:
 
-    #. Drag and drop a ``QFrame`` under the QLabel added at **Step 3.6**.
+    #. Drag and drop a ``QFrame`` under the QLabel added at **Step 3.5**.
     #. Set the ``frameShape`` property to ``StyledPanel``.
     #. Set the ``frameShadow`` property to ``Raised``
     #. Set the ``stylesheet`` property to:
@@ -178,35 +168,36 @@ The finished result will look like this:
                 border-bottom-right-radius: 15px;
             }
 
-  * **Step 3.8.**
+  * **Step 3.7.**
 
-    The eight widget that we will add is a ``PyDMEmbeddedDisplay``, which will
+    The seventh widget that we will add is a ``PyDMEmbeddedDisplay``, which will
     display the ``inline_motor.ui`` with information for our first motor axis:
 
-    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``QFrame`` added at **Step 3.7**.
-    #. Right-click at the ``QFrame`` from **Step 3.7** and select ``Layout >> Layout Vertically``.
-    #. Set the ``macros`` property to ``{"MOTOR":"IOC:m1"}``.
-    #. Set the ``filename`` property to ``inline_motor.ui``.
+    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``QFrame`` added at **Step 3.6**.
+    #. Right-click at the ``QFrame`` from **Step 3.6** and select ``Layout >> Layout Vertically``.
+    #. Set the embedded display's ``macros`` property to ``{"MOTOR":"IOC:m1"}``.
+    #. Set the embedded display's ``filename`` property to ``inline_motor.ui``.
 
-  * **Step 3.9.**
+  * **Step 3.8.**
 
-    The nineth widget that we will add is a ``PyDMEmbeddedDisplay``, which will
+    The eighth widget that we will add is a ``PyDMEmbeddedDisplay``, which will
     display the ``inline_motor.ui`` with information for our second motor axis:
 
     #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``QFrame`` added at **Step 3.7**.
-    #. Set the ``macros`` property to ``{"MOTOR":"IOC:m2"}``.
-    #. Set the ``filename`` property to ``inline_motor.ui``.
+    #. Set the embedded display's ``macros`` property to ``{"MOTOR":"IOC:m2"}``.
+    #. Set the embedded display's ``filename`` property to ``inline_motor.ui``.
 
-  * **Step 3.10.**
+  * **Step 3.9.**
 
-    Finally, the tenth widget that we will add is a ``PyDMRelatedDisplayButton``, which will
+    Finally, the ninth widget that we will add is a ``PyDMRelatedDisplayButton``, which will
     open the ``All Motors`` screen that will be developed :ref:`later <PurePython>`:
 
     #. Drag and drop a ``PyDMRelatedDisplayButton`` into the ``QVBoxLayout`` added at **Step 2**.
+    #. Set the ``text`` property of this label to ``View All Monitors``.
     #. Set the ``displayFilename`` property to ``all_motors.py``.
     #. Remove the mark at the ``openInNewWindow`` property.
 
-  * **Step 3.11.**
+  * **Step 3.10.**
 
     Once all the widgets are added to the form, it is now time to adjust the layouts
     and make sure that all is well positioned and behaving nicely.
@@ -252,12 +243,7 @@ The finished result will look like this:
 
 * **Step 4.**
 
-  Save this file as ``main.ui``.
-
-  .. warning::
-     For this tutorial it is important to use this file name, as it will be referenced
-     at the other sections. If you change it please remember to also change at the
-     next steps when referenced.
+  Save this file as ``main.ui`` again if necessary.
 
 * **Step 5.**
 

--- a/docs/source/action/intro_designer.rst
+++ b/docs/source/action/intro_designer.rst
@@ -28,7 +28,7 @@ building user interfaces.
       C:\> designer
 
 Once you open Designer, you'll be greeted by a mostly
-blank screen, with a list of widgets on the left, and a property inspector on the
+blank screen, with a list of widgets on the left, and a Property Editor on the
 right.
 
 .. figure:: /_static/action/designer.png

--- a/docs/source/action/little_code.rst
+++ b/docs/source/action/little_code.rst
@@ -29,7 +29,16 @@ That is accomplished by subclassing `Display` (See :ref:`Display` for more detai
    The first thing that we will do is add the imports needed for the code that
    will follow.
 
-   .. code-block:: python
+   Let's create a new file and save this file as ``main.py``.
+
+   .. warning::
+        For this tutorial it is important to use this file name as it will be referenced
+        at the other sections. If you change it please remember to also change in the
+        other steps when referenced.
+
+  Enter the following first lines of code:
+
+  .. code-block:: python
 
        import time
        from os import path
@@ -75,6 +84,7 @@ That is accomplished by subclassing `Display` (See :ref:`Display` for more detai
   #. ``ui_filepath`` method returning the full path to the ``ui_filename`` so PyDM
      can properly load it.
 
+
   * **Step 2.1.**
 
     Adding code to the ``process_image`` callback method so we can calculate the
@@ -102,6 +112,7 @@ That is accomplished by subclassing `Display` (See :ref:`Display` for more detai
     to calculate the coordinates for the maximum spot and save it to ``self.blob``.
     At the end, this method returns the unmodified image, which the ImageView will display.
 
+
   * **Step 2.2.**
 
     Adding code to the ``show_blob`` method so we update the ``QLabel`` with the
@@ -123,12 +134,7 @@ That is accomplished by subclassing `Display` (See :ref:`Display` for more detai
 
 * **Step 3.**
 
-  Save this file as ``main.py``.
-
-  .. warning::
-     For this tutorial it is important to use this file name as it will be referenced
-     at the other sections. If you change it please remember to also change in the
-     other steps when referenced.
+  Save this file as ``main.py`` again if necessary.
 
 * **Step 4.**
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -24,7 +24,7 @@ Oracle VirtualBox is available for Windows, OS X and Linux hosts.
 This file is not a complete Virtual Machine dump that can be imported but instead a disk.
 
 In order to use this disk, start by creating a new virtual Machine, select Type as ``Linux`` and Version as ``Ubuntu (64-bit)``.
-Configure the amount of memory to use (something greater or equal 2048MB should do it.
+Configure the amount of memory to use (something greater than or equal to 4096 MB should do it.
 Make sure to select ``Use an existing virtual hard disk file.`` and select the extracted ``.vmdk`` file.
 
 .. figure:: /_static/new_vm.png
@@ -62,7 +62,8 @@ Simulated EPICS IOCs
 ++++++++++++++++++++
 
 This machine comes with simulated motors and cameras.
-The IOCs can be started through their launcher scripts available at:
+The IOCs can be started through their launcher scripts available below. You can run these launcher scripts concurrently.
+Each script can be on either a terminal tab or console.
 
 .. code-block:: bash
 
@@ -76,6 +77,9 @@ The IOCs can be started through their launcher scripts available at:
 
     # For the linking IOC
     ./simLinker
+
+.. note::
+   You must activate the tutorial Python environment before starting the IOCs.
 
 For AreaDetector (cameras):
 


### PR DESCRIPTION
I did not fix the following issues. If you can provide the GIFs, I can link them to the text:

1. expert_layout.gif should illustrate dragging of a VBoxLayout, not a GridLayout
2. We need two more GIFs, one for steps 3.2 - 3.3, and the other for steps 3.4 - 3.7 (these are steps that involve dragging the same widgets, but the settings may vary).
