### PR TITLE
Display classes

### DIFF
--- a/docs/source/action/designer_expert.rst
+++ b/docs/source/action/designer_expert.rst
@@ -39,7 +39,7 @@ The finished result will look like this:
 
 * **Step 2.**
 
-  With the new form available, let's add a ``QVBoxLayout`` widget and make
+  With the new form available, let's add a ``Vertical Layout`` widget and make
   it fill the whole form. Let's select ``Layout Vertically`` for the Form.
 
   .. figure:: /_static/action/inline/inline_layout.gif
@@ -60,7 +60,7 @@ The finished result will look like this:
 
     The first ``Label`` will be the title of our screen:
 
-    #. Drag and drop a ``Label`` into the previously added ``QVBoxLayout``.
+    #. Drag and drop a ``Label`` into the previously added ``Vertical Layout``.
     #. Set the ``text`` property of this label to: ``Configuring Motor: ${MOTOR}``.
 
        .. note::
@@ -96,7 +96,7 @@ The finished result will look like this:
     The second widget that we will add is a ``Frame``, which will be the container
     of the fields in our form:
 
-    #. Drag and drop a ``Frame`` into the previously added ``QVBoxLayout`` under
+    #. Drag and drop a ``Frame`` into the previously added ``Vertical Layout`` under
        the ``Label`` that was added at **Step 3.1**.
     #. Set the ``frameShape`` property to ``StyledPanel``.
     #. Set the ``frameShadow`` property to ``Raised``.

--- a/docs/source/action/designer_expert.rst
+++ b/docs/source/action/designer_expert.rst
@@ -58,9 +58,9 @@ The finished result will look like this:
 
   * **Step 3.1.**
 
-    The first ``QLabel`` will be the title of our screen:
+    The first ``Label`` will be the title of our screen:
 
-    #. Drag and drop a ``QLabel`` into the previously added ``QVBoxLayout``.
+    #. Drag and drop a ``Label`` into the previously added ``QVBoxLayout``.
     #. Set the ``text`` property of this label to: ``Configuring Motor: ${MOTOR}``.
 
        .. note::
@@ -97,7 +97,7 @@ The finished result will look like this:
     of the fields in our form:
 
     #. Drag and drop a ``QFrame`` into the previously added ``QVBoxLayout`` under
-       the ``QLabel`` that was added at **Step 3.1**.
+       the ``Label`` that was added at **Step 3.1**.
     #. Set the ``frameShape`` property to ``StyledPanel``.
     #. Set the ``frameShadow`` property to ``Raised``.
     #. In order to add some nice rounded corners to this frame, add the following
@@ -137,17 +137,17 @@ The finished result will look like this:
   * **Step 3.4.**
 
     Now that we have our ``QFormLayout`` ready, it is time to start adding the form
-    widgets. Let's start with the first pair of ``QLabel`` and ``PyDMLineEdit`` that
+    widgets. Let's start with the first pair of ``Label`` and ``PyDMLineEdit`` that
     will be used to edit the **Description** of the Motor:
 
-    #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout``.
+    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout``.
     #. Set the ``text`` property to ``Description:``.
     #. Drag and drop a ``PyDMLineEdit`` into the ``QFormLayout`` paying attention to
-       add it on the right side of the previously added ``QLabel``.
+       add it on the right side of the previously added ``Label``.
 
        .. note::
 
-          The area that will match the ``QLabel`` will be highlighted with red
+          The area that will match the ``Label`` will be highlighted with red
           borders. When that happens you will know that the widget will be placed
           at the expected place.
 
@@ -156,10 +156,10 @@ The finished result will look like this:
 
   * **Step 3.5.**
 
-    Let's now add the second pair of ``QLabel`` and ``PyDMLineEdit`` that
+    Let's now add the second pair of ``Label`` and ``PyDMLineEdit`` that
     will be used to edit the **Position** of the Motor:
 
-    #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
        under the previously added components.
 
        .. note::
@@ -169,7 +169,7 @@ The finished result will look like this:
 
     #. Set the ``text`` property to ``Position:``.
     #. Drag and drop a ``PyDMLineEdit`` into the ``QFormLayout`` paying attention to
-       add it on the side of the previously added ``QLabel``.
+       add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.VAL``.
     #. Set the ``displayFormat`` property to ``Decimal``.
     #. Select the ``showUnits`` property.
@@ -177,28 +177,28 @@ The finished result will look like this:
 
   * **Step 3.6.**
 
-    Let's now add a ``QLabel``, and this time, a ``PyDMLabel`` that
+    Let's now add a ``Label``, and this time, a ``PyDMLabel`` that
     will be used to read the **Readback Position** of the Motor:
 
-    #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Readback:``.
     #. Drag and drop a ``PyDMLabel`` to the ``QFormLayout`` paying attention to
-       add it on the right side of the previously added ``QLabel``.
+       add it on the right side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.RBV``.
     #. Set the ``displayFormat`` property to ``Decimal``.
     #. Select the ``showUnits`` property.
 
   * **Step 3.7.**
 
-    Let's add another ``QLabel`` and ``PyDMLineEdit`` pair that will be used
+    Let's add another ``Label`` and ``PyDMLineEdit`` pair that will be used
     to edit the **Velocity** of the Motor:
 
-    #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Velocity:``.
     #. Drag and drop a ``PyDMLineEdit`` to the ``QFormLayout`` paying attention to
-       add it on the side of the previously added ``QLabel``.
+       add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.VELO``.
     #. Set the ``displayFormat`` property to ``Decimal``.
     #. Select the ``showUnits`` property.
@@ -207,14 +207,14 @@ The finished result will look like this:
 
   * **Step 3.8.**
 
-    And now to the last ``QLabel`` and ``PyDMLineEdit`` pair that will be used
+    And now to the last ``Label`` and ``PyDMLineEdit`` pair that will be used
     to edit the **Acceleration** of the Motor:
 
-    #. Drag and drop a ``QLabel`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Acceleration:``.
     #. Drag and drop a ``PyDMLineEdit`` to the ``QFormLayout`` paying attention to
-       add it on the side of the previously added ``QLabel``.
+       add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.ACCL``.
     #. Set the ``displayFormat`` property to ``Decimal``.
     #. Select the ``showUnits`` property.

--- a/docs/source/action/designer_expert.rst
+++ b/docs/source/action/designer_expert.rst
@@ -93,10 +93,10 @@ The finished result will look like this:
 
   * **Step 3.2.**
 
-    The second widget that we will add is a ``QFrame``, which will be the container
+    The second widget that we will add is a ``Frame``, which will be the container
     of the fields in our form:
 
-    #. Drag and drop a ``QFrame`` into the previously added ``QVBoxLayout`` under
+    #. Drag and drop a ``Frame`` into the previously added ``QVBoxLayout`` under
        the ``Label`` that was added at **Step 3.1**.
     #. Set the ``frameShape`` property to ``StyledPanel``.
     #. Set the ``frameShadow`` property to ``Raised``.
@@ -116,10 +116,10 @@ The finished result will look like this:
     Now to ensure the alignment and positioning of the form content, let's add a
     ``QFormLayout``:
 
-    #. Drag and drop a ``QFormLayout`` into the previously added ``QFrame``.
-    #. Right-click the ``QFrame`` and select ``Layout > Layout Vertically``.
+    #. Drag and drop a ``QFormLayout`` into the previously added ``Frame``.
+    #. Right-click the ``Frame`` and select ``Layout > Layout Vertically``.
 
-       - This will make the QFormLayout fill the whole space of the ``QFrame``
+       - This will make the QFormLayout fill the whole space of the ``Frame``
          and make our form behave better when resizing.
 
     #. Set the ``frameShadow`` property to ``Raised``.

--- a/docs/source/action/designer_expert.rst
+++ b/docs/source/action/designer_expert.rst
@@ -114,12 +114,12 @@ The finished result will look like this:
   * **Step 3.3.**
 
     Now to ensure the alignment and positioning of the form content, let's add a
-    ``QFormLayout``:
+    ``Form Layout``:
 
-    #. Drag and drop a ``QFormLayout`` into the previously added ``Frame``.
+    #. Drag and drop a ``Form Layout`` into the previously added ``Frame``.
     #. Right-click the ``Frame`` and select ``Layout > Layout Vertically``.
 
-       - This will make the QFormLayout fill the whole space of the ``Frame``
+       - This will make the ``Form Layout`` fill the whole space of the ``Frame``
          and make our form behave better when resizing.
 
     #. Set the ``frameShadow`` property to ``Raised``.
@@ -136,13 +136,13 @@ The finished result will look like this:
 
   * **Step 3.4.**
 
-    Now that we have our ``QFormLayout`` ready, it is time to start adding the form
+    Now that we have our ``Form Layout`` ready, it is time to start adding the form
     widgets. Let's start with the first pair of ``Label`` and ``PyDMLineEdit`` that
     will be used to edit the **Description** of the Motor:
 
-    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout``.
+    #. Drag and drop a ``Label`` into the the previously added ``Form Layout``.
     #. Set the ``text`` property to ``Description:``.
-    #. Drag and drop a ``PyDMLineEdit`` into the ``QFormLayout`` paying attention to
+    #. Drag and drop a ``PyDMLineEdit`` into the ``Form Layout`` paying attention to
        add it on the right side of the previously added ``Label``.
 
        .. note::
@@ -159,7 +159,7 @@ The finished result will look like this:
     Let's now add the second pair of ``Label`` and ``PyDMLineEdit`` that
     will be used to edit the **Position** of the Motor:
 
-    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``Form Layout`` right
        under the previously added components.
 
        .. note::
@@ -168,7 +168,7 @@ The finished result will look like this:
           know that the widget will be placed at the expected place.
 
     #. Set the ``text`` property to ``Position:``.
-    #. Drag and drop a ``PyDMLineEdit`` into the ``QFormLayout`` paying attention to
+    #. Drag and drop a ``PyDMLineEdit`` into the ``Form Layout`` paying attention to
        add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.VAL``.
     #. Set the ``displayFormat`` property to ``Decimal``.
@@ -180,10 +180,10 @@ The finished result will look like this:
     Let's now add a ``Label``, and this time, a ``PyDMLabel`` that
     will be used to read the **Readback Position** of the Motor:
 
-    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``Form Layout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Readback:``.
-    #. Drag and drop a ``PyDMLabel`` to the ``QFormLayout`` paying attention to
+    #. Drag and drop a ``PyDMLabel`` to the ``Form Layout`` paying attention to
        add it on the right side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.RBV``.
     #. Set the ``displayFormat`` property to ``Decimal``.
@@ -194,10 +194,10 @@ The finished result will look like this:
     Let's add another ``Label`` and ``PyDMLineEdit`` pair that will be used
     to edit the **Velocity** of the Motor:
 
-    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``Form Layout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Velocity:``.
-    #. Drag and drop a ``PyDMLineEdit`` to the ``QFormLayout`` paying attention to
+    #. Drag and drop a ``PyDMLineEdit`` to the ``Form Layout`` paying attention to
        add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.VELO``.
     #. Set the ``displayFormat`` property to ``Decimal``.
@@ -210,10 +210,10 @@ The finished result will look like this:
     And now to the last ``Label`` and ``PyDMLineEdit`` pair that will be used
     to edit the **Acceleration** of the Motor:
 
-    #. Drag and drop a ``Label`` into the the previously added ``QFormLayout`` right
+    #. Drag and drop a ``Label`` into the the previously added ``Form Layout`` right
        under the previously added components.
     #. Set the ``text`` property to ``Acceleration:``.
-    #. Drag and drop a ``PyDMLineEdit`` to the ``QFormLayout`` paying attention to
+    #. Drag and drop a ``PyDMLineEdit`` to the ``Form Layout`` paying attention to
        add it on the side of the previously added ``Label``.
     #. Set the ``channel`` property to ``ca://${MOTOR}.ACCL``.
     #. Set the ``displayFormat`` property to ``Decimal``.

--- a/docs/source/action/designer_inline.rst
+++ b/docs/source/action/designer_inline.rst
@@ -204,7 +204,7 @@ The finished result will look like this:
     #. Drag and drop a ``PyDMRelatedDisplayButton`` at the ``GridLayout`` on the
        side of the previously added ``PyDMPushButton``.
     #. Set the ``text`` property to ``Engineer...``.
-    #. Set the ``displayFilename`` property to ``expert_motor.ui``.
+    #. Add the string ``exper_motor.ui`` to the ``filenames`` property.
 
        .. note::
 

--- a/docs/source/action/designer_main.rst
+++ b/docs/source/action/designer_main.rst
@@ -205,6 +205,7 @@ The finished result will look like this:
     #. Drag and drop a ``PyDMRelatedDisplayButton`` into the ``Vertical Layout`` added in **Step 2**.
     #. Add the string ``all_motors.py`` to the ``filenames`` property.
     #. Uncheck the ``openInNewWindow`` property.
+    #. Set the ``text`` property to: ``View All Motors``
 
   * **Step 3.11.**
 

--- a/docs/source/action/designer_main.rst
+++ b/docs/source/action/designer_main.rst
@@ -102,7 +102,7 @@ The finished result will look like this:
     The fourth widget that we will add is a ``QLabel``, which will be updated with
     the result of the calculation of beam position in the next section (:ref:`LittleCode`):
 
-    #. Drag and drop a ``Vertical Layout`` into the ``Vertical Layout`` that was added in
+    #. Drag and drop a ``Label`` into the ``Vertical Layout`` that was added in
        **Step 3.3**.
     #. Set the ``objectName`` property of this widget to ``lbl_blobs``.
 

--- a/docs/source/action/designer_main.rst
+++ b/docs/source/action/designer_main.rst
@@ -54,9 +54,9 @@ The finished result will look like this:
 
   * **Step 3.1.**
 
-    The first ``QLabel`` will be the title of our screen:
+    The first ``Label`` will be the title of our screen:
 
-    #. Drag and drop a ``QLabel`` into the previously added ``Vertical Layout``.
+    #. Drag and drop a ``Label`` into the previously added ``Vertical Layout``.
     #. Set the ``text`` property of this label to: ``Beam Alignment``.
     #. In order to make the label look better as a title, add the following to
        the ``stylesheet`` property:
@@ -82,7 +82,7 @@ The finished result will look like this:
     the image coming from our camera:
 
     #. Drag and drop a ``PyDMImageView`` into the previously added ``Vertical Layout`` under
-       the ``QLabel`` that was added at **Step 3.1**.
+       the ``Label`` that was added at **Step 3.1**.
     #. Set the ``imageChannel`` property to ``ca://13SIM1:image1:ArrayData``.
     #. Set the ``widthChannel`` property to ``ca://13SIM1:image1:ArraySize1_RBV``.
     #. Set the ``readingOrder`` property to ``Clike``.
@@ -99,7 +99,7 @@ The finished result will look like this:
 
   * **Step 3.4.**
 
-    The fourth widget that we will add is a ``QLabel``, which will be updated with
+    The fourth widget that we will add is a ``Label``, which will be updated with
     the result of the calculation of beam position in the next section (:ref:`LittleCode`):
 
     #. Drag and drop a ``Label`` into the ``Vertical Layout`` that was added in
@@ -118,7 +118,7 @@ The finished result will look like this:
 
   * **Step 3.5.**
 
-    The fifth widget that we will add is a ``QLabel``, which will be updated with
+    The fifth widget that we will add is a ``Label``, which will be updated with
     the result of the calculation of beam position in the next section (:ref:`LittleCode`):
 
     #. Drag and drop a ``Vertical Layout`` into the ``Vertical Layout`` that was added in
@@ -137,11 +137,11 @@ The finished result will look like this:
 
   * **Step 3.6.**
 
-    The sixth widget that we will add is another ``QLabel``, which will show the title
+    The sixth widget that we will add is another ``Label``, which will show the title
     of our controls area:
 
-    #. Drag and drop a ``QLabel`` into the ``Vertical Layout`` that was added in
-       **Step 3.3** right under the QLabel added in **Step 3.5**.
+    #. Drag and drop a ``Label`` into the ``Vertical Layout`` that was added in
+       **Step 3.3** right under the ``Label`` added in **Step 3.5**.
     #. Set the ``text`` property of this label to: ``Controls``.
     #. In order to make the label look better as a title, add the following to
        the ``stylesheet`` property:
@@ -162,10 +162,10 @@ The finished result will look like this:
 
   * **Step 3.7.**
 
-    The seventh widget that we will add is a ``QFrame``, which will be the container
+    The seventh widget that we will add is a ``Frame``, which will be the container
     for our two motors' ``Embedded Displays``:
 
-    #. Drag and drop a ``QFrame`` under the QLabel added in **Step 3.6**.
+    #. Drag and drop a ``Frame`` under the ``Label`` added in **Step 3.6**.
     #. Set the ``frameShape`` property to ``StyledPanel``.
     #. Set the ``frameShadow`` property to ``Raised``
     #. Set the ``stylesheet`` property to:
@@ -183,8 +183,8 @@ The finished result will look like this:
     The eight widget that we will add is a ``PyDMEmbeddedDisplay``, which will
     display the ``inline_motor.ui`` with information for our first motor axis:
 
-    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``QFrame`` added in **Step 3.7**.
-    #. Right-click the ``QFrame`` from **Step 3.7** and select ``Layout >> Layout Vertically``.
+    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``Frame`` added in **Step 3.7**.
+    #. Right-click the ``Frame`` from **Step 3.7** and select ``Layout >> Layout Vertically``.
     #. Set the ``macros`` property to ``{"MOTOR":"IOC:m1"}``.
     #. Set the ``filename`` property to ``inline_motor.ui``.
 
@@ -193,7 +193,7 @@ The finished result will look like this:
     The ninth widget that we will add is a ``PyDMEmbeddedDisplay``, which will
     display the ``inline_motor.ui`` with information for our second motor axis:
 
-    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``QFrame`` added in **Step 3.7**.
+    #. Drag and drop a ``PyDMEmbeddedDisplay`` into the ``Frame`` added in **Step 3.7**.
     #. Set the ``macros`` property to ``{"MOTOR":"IOC:m2"}``.
     #. Set the ``filename`` property to ``inline_motor.ui``.
 

--- a/docs/source/action/designer_main.rst
+++ b/docs/source/action/designer_main.rst
@@ -37,7 +37,7 @@ The finished result will look like this:
 
 * **Step 2.**
 
-  With the new form available, let's add a ``QVBoxLayout`` widget and make
+  With the new form available, let's add a ``Vertical Layout`` widget and make
   it fill the whole form. Let's select ``Layout Vertically`` for the Form.
 
   .. figure:: /_static/action/inline/inline_layout.gif
@@ -56,7 +56,7 @@ The finished result will look like this:
 
     The first ``QLabel`` will be the title of our screen:
 
-    #. Drag and drop a ``QLabel`` into the previously added ``QVBoxLayout``.
+    #. Drag and drop a ``QLabel`` into the previously added ``Vertical Layout``.
     #. Set the ``text`` property of this label to: ``Beam Alignment``.
     #. In order to make the label look better as a title, add the following to
        the ``stylesheet`` property:
@@ -81,7 +81,7 @@ The finished result will look like this:
     The second widget that we will add is a ``PyDMImageView``, which will display
     the image coming from our camera:
 
-    #. Drag and drop a ``PyDMImageView`` into the previously added ``QVBoxLayout`` under
+    #. Drag and drop a ``PyDMImageView`` into the previously added ``Vertical Layout`` under
        the ``QLabel`` that was added at **Step 3.1**.
     #. Set the ``imageChannel`` property to ``ca://13SIM1:image1:ArrayData``.
     #. Set the ``widthChannel`` property to ``ca://13SIM1:image1:ArraySize1_RBV``.
@@ -91,10 +91,10 @@ The finished result will look like this:
 
   * **Step 3.3.**
 
-    The third widget that we will add is a ``QVBoxLayout``, which will be the
+    The third widget that we will add is a ``Vertical Layout``, which will be the
     placeholder for the controls area of the screen:
 
-    #. Drag and drop a ``QVBoxLayout`` into the previously added ``QVBoxLayout`` under
+    #. Drag and drop a ``Vertical Layout`` into the previously added ``Vertical Layout`` under
        the ``PyDMImageView`` that was added at **Step 3.2**.
 
   * **Step 3.4.**
@@ -102,7 +102,7 @@ The finished result will look like this:
     The fourth widget that we will add is a ``QLabel``, which will be updated with
     the result of the calculation of beam position in the next section (:ref:`LittleCode`):
 
-    #. Drag and drop a ``QVBoxLayout`` into the ``QVBoxLayout`` that was added in
+    #. Drag and drop a ``Vertical Layout`` into the ``Vertical Layout`` that was added in
        **Step 3.3**.
     #. Set the ``objectName`` property of this widget to ``lbl_blobs``.
 
@@ -121,7 +121,7 @@ The finished result will look like this:
     The fifth widget that we will add is a ``QLabel``, which will be updated with
     the result of the calculation of beam position in the next section (:ref:`LittleCode`):
 
-    #. Drag and drop a ``QVBoxLayout`` into the ``QVBoxLayout`` that was added in
+    #. Drag and drop a ``Vertical Layout`` into the ``Vertical Layout`` that was added in
        **Step 3.3**.
     #. Set the ``objectName`` property of this widget to ``lbl_blobs``.
 
@@ -140,7 +140,7 @@ The finished result will look like this:
     The sixth widget that we will add is another ``QLabel``, which will show the title
     of our controls area:
 
-    #. Drag and drop a ``QLabel`` into the ``QVBoxLayout`` that was added in
+    #. Drag and drop a ``QLabel`` into the ``Vertical Layout`` that was added in
        **Step 3.3** right under the QLabel added in **Step 3.5**.
     #. Set the ``text`` property of this label to: ``Controls``.
     #. In order to make the label look better as a title, add the following to
@@ -202,8 +202,8 @@ The finished result will look like this:
     Finally, the tenth widget that we will add is a ``PyDMRelatedDisplayButton``, which will
     open the ``All Motors`` screen that will be developed :ref:`later <PurePython>`:
 
-    #. Drag and drop a ``PyDMRelatedDisplayButton`` into the ``QVBoxLayout`` added in **Step 2**.
-    #. Set the ``displayFilename`` property to ``all_motors.py``.
+    #. Drag and drop a ``PyDMRelatedDisplayButton`` into the ``Vertical Layout`` added in **Step 2**.
+    #. Add the string ``all_motors.py`` to the ``filenames`` property.
     #. Uncheck the ``openInNewWindow`` property.
 
   * **Step 3.11.**


### PR DESCRIPTION
Summary of changes:
- Replaced all designer class references to widget search labels
- Set label text property to "View All Motors" (as shown in the gif) in step 3.10 of designer_main.rst
- Removed the deprecated displayFilename property from the PyDMRelatedDisplayButton class and added instructions for adding the filename string to the filenames property